### PR TITLE
Get the username out of the user email address in Pagerduty

### DIFF
--- a/src/pd_observer/cli.py
+++ b/src/pd_observer/cli.py
@@ -156,11 +156,12 @@ def get_oncall(pd_api_token,
 
     payload = {}
     payload['time_zone'] = 'UTC'
+    payload['include[]'] = 'users'
     payload['schedule_ids[]'] = schedule_id
 
     r = requests.get(url, headers=headers, params=payload)
     try:
-        sid = r.json()['oncalls'][0]['user']['summary']
+        sid = r.json()['oncalls'][0]['user']['email'].split('@')[0]
     except IndexError:
         log.debug("Schedule Not Found for: {}".format(schedule_id))
         sid = None


### PR DESCRIPTION
Changes proposed on this PR:

- Get the username of the oncall from the Pagerduty email address. Fix #4 
